### PR TITLE
Fix random test syntax

### DIFF
--- a/tests/random-tests.rkt
+++ b/tests/random-tests.rkt
@@ -14,12 +14,12 @@
   (cond
     [(equal? 'failed ς) #f]
     [(redex-match? tglc (BLAME weird-L) ς) #t]
-    [else #f])))
+    [else #f]))
 
 (redex-check tglc ((⇓ v (S a r)) σ β) 
 	(let ([target (with-handlers ([exn:fail? (λ (exn) 'failed)])
 										(apply-reduction-relation -→ (term ((⇓ v (S a r)) σ β))))])
-  (if (reduces-to-blame? target) 
+  (if (reduces-to-blame? target)
       (term (blame-not-empty? target))
-      #t)
+      #t))
   #:attempts 1000000)


### PR DESCRIPTION
## Summary
- fix mismatched parenthesis in `tests/random-tests.rkt`

## Testing
- `xvfb-run -a raco test --drdr tests/unit-tests.rkt`


------
https://chatgpt.com/codex/tasks/task_e_684b3be1fbb08330a4d984caa08dd34d